### PR TITLE
LIBFCREPO-170. Use dot-env for deployed servers.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@
 
 # Ignore the configuration file
 config/pcdm2manifest.yml
+
+# Ignore environment variables
+/.env

--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,9 @@ gem 'jbuilder', '~> 2.5'
 # Use Capistrano for deployment
 # gem 'capistrano-rails', group: :development
 
+# dotenv - For storing production configuration parameters
+gem 'dotenv-rails', '~> 2.1.1'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platform: :mri

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,6 +50,10 @@ GEM
     coffee-script-source (1.10.0)
     concurrent-ruby (1.0.2)
     debug_inspector (0.0.2)
+    dotenv (2.1.1)
+    dotenv-rails (2.1.1)
+      dotenv (= 2.1.1)
+      railties (>= 4.0, < 5.1)
     erubis (2.7.0)
     execjs (2.7.0)
     faraday (0.9.2)
@@ -162,6 +166,7 @@ PLATFORMS
 DEPENDENCIES
   byebug
   coffee-rails (~> 4.2)
+  dotenv-rails (~> 2.1.1)
   faraday
   faraday_middleware
   jbuilder (~> 2.5)


### PR DESCRIPTION
Use the dot-env gem and a .env file to hold sensitive info for the deployed
application on iiifdev.

https://issues.umd.edu/browse/LIBFCREPO-170