### PR TITLE
LIBFCREPO-207. Added client_cert and client_key config options.

### DIFF
--- a/config/pcdm2manifest.yml.dist
+++ b/config/pcdm2manifest.yml.dist
@@ -5,3 +5,5 @@ fcrepo_base_uri: https://fcrepolocal/fcrepo/rest/
 iiif_image_uri: https://iiiflocal/images/
 iiif_manifest_uri: https://iiiflocal/manifests/
 id_prefix: "fcrepo:"
+client_cert: /apps/iiif/ssl/iiif.pem
+client_key: /apps/iiif/ssl/iiif.key


### PR DESCRIPTION
If present, use them as filenames for client certificate authentication. Also, only send the username and password as HTTP Basic credentials if they are set in the config file.

https://issues.umd.edu/browse/LIBFCREPO-207