### PR TITLE
LIBFCREPO-270. Prefix and escape the image identifier.

### DIFF
--- a/app/controllers/concerns/manifest_helper.rb
+++ b/app/controllers/concerns/manifest_helper.rb
@@ -80,7 +80,7 @@ module ManifestHelper
       page[:image_mime_type] = image[:mime_type]
       page[:canvas_id] = base_id + '/canvas/' + get_formatted_id(page_id)
       page[:image_id] = base_id + '/annotation/' + get_formatted_id(image_id)
-      page[:resource_id] = IMAGE_URL + get_prefixed_id(image_id)
+      page[:resource_id] = IMAGE_URL + get_formatted_id(image_id)
     end
   end
 

--- a/app/views/manifests/show.json.jb
+++ b/app/views/manifests/show.json.jb
@@ -56,7 +56,7 @@ json = {
   'attribution': @doc[:attribution],
 
   'logo': {
-    '@id': 'http://wwwdev.lib.umd.edu/images/wrapper/liblogo.png',
+    '@id': 'https://www.lib.umd.edu/images/wrapper/liblogo.png',
     'service': {
       '@context': 'http://iiif.io/api/image/2/context.json',
       '@id': 'http://example.org/service/inst1',

--- a/config/application.rb
+++ b/config/application.rb
@@ -19,6 +19,6 @@ module PcdmManifests
     config.solr_url = ENV['SOLR_URL'] || 'https://solrlocal:8984/solr/fedora4/'
     config.fcrepo_url = ENV['FCREPO_URL'] || 'https://fcrepolocal/fcrepo/rest/'
     config.iiif_image_url = ENV['IIIF_IMAGE_URL'] || 'https://iiiflocal/images/'
-    config.iiif_manifest_url = ENV['IIIF_MANIFEST_URL'] || 'https://iiiflocal/manifesta/'
+    config.iiif_manifest_url = ENV['IIIF_MANIFEST_URL'] || 'https://iiiflocal/manifests/'
   end
 end


### PR DESCRIPTION
This ensures compliance with the IIIF Image API spec.

Also fixed a couple other minor issues:
* corrected typo in default manifests URL
* changed logo image URL to point to the https resource on production web server; this will prevent mixed content warnings on pages that embed to Mirador viewer

https://issues.umd.edu/browse/LIBFCREPO-270