### PR TITLE
LIBFCREPO-336. Retain text query when redirecting from page to issue manifest.

### DIFF
--- a/app/controllers/manifests_controller.rb
+++ b/app/controllers/manifests_controller.rb
@@ -16,7 +16,8 @@ class ManifestsController < ApplicationController
       prepare_for_render(@doc, params[:q])
       render :show
     when "page"
-      redirect_to '/manifests/' + get_formatted_id(get_path(@doc[:page_issue])) + '/manifest', status: :see_other
+      page_id = get_prefixed_id(get_path(@doc[:page_issue]))
+      redirect_to manifest_url(id: page_id, q: params[:q]), status: :see_other
     else
       raise ActionController::RoutingError.new('Not an PCDM Object/File: ' + prefixed_id)
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
-  get 'manifests/:id/manifest' => 'manifests#show', defaults: {format: :json}
+  get 'manifests/:id/manifest' => 'manifests#show', defaults: {format: :json}, as: 'manifest'
   get 'manifests/:id/list/:list_id' => 'manifests#show_list'
   get 'manifests' => 'manifests#index'
 end


### PR DESCRIPTION
Added a name to the manifest route to get access to the manifest_url and manifest_path helper methods.

https://issues.umd.edu/browse/LIBFCREPO-336