### PR TITLE
LIBIIIF-57. List manifest and canvas components.

### DIFF
--- a/app/controllers/manifests_controller.rb
+++ b/app/controllers/manifests_controller.rb
@@ -11,11 +11,10 @@ class ManifestsController < ApplicationController
     prefixed_id = params[:id]
     verify_prefix(prefixed_id)
     @doc = get_solr_doc(prefixed_id)
-    case @doc[:component].downcase
-    when "issue"
+    if is_manifest_level? @doc[:component]
       prepare_for_render(@doc, params[:q])
       render :show
-    when "page"
+    elsif is_canvas_level? @doc[:component]
       page_id = get_prefixed_id(get_path(@doc[:page_issue]))
       redirect_to manifest_url(id: page_id, q: params[:q]), status: :see_other
     else
@@ -23,6 +22,7 @@ class ManifestsController < ApplicationController
     end
   end
 
+  # GET /manifests/:id/list/:list_id
   def show_list
     prefix, path = params[:id].split /:/
     manifest_id = "#{prefix}:#{encode(path)}"

--- a/app/views/manifests/show.json.jb
+++ b/app/views/manifests/show.json.jb
@@ -68,12 +68,7 @@ json = {
   'attribution': @doc[:attribution],
 
   'logo': {
-    '@id': 'https://www.lib.umd.edu/images/wrapper/liblogo.png',
-    'service': {
-      '@context': 'http://iiif.io/api/image/2/context.json',
-      '@id': 'http://example.org/service/inst1',
-      'profile': 'http://iiif.io/api/image/2/profiles/level2.json'
-    }
+    '@id': 'https://www.lib.umd.edu/images/wrapper/liblogo.png'
   },
 
   'sequences': [


### PR DESCRIPTION
The manifest controller will consult those lists when deciding whether to render the manifest or redirect.

Also:
* return empty thumbnail and page sequence if there are no pages, instead of throwing an error
* removed leftover example code from the manifest template.

https://issues.umd.edu/browse/LIBIIIF-57