### PR TITLE
LIBIIIF-58. Respond with HTTP error statuses.

### DIFF
--- a/app/controllers/concerns/manifest_helper.rb
+++ b/app/controllers/concerns/manifest_helper.rb
@@ -5,6 +5,46 @@ require 'erb'
 module ManifestHelper
   extend ActiveSupport::Concern
 
+  # RFC 7807 Problem Details format
+  # https://tools.ietf.org/html/rfc7807
+  module ProblemDetails
+    def to_h
+      {
+        title: self.title,
+        details: self.message,
+        status: self.status
+      }
+    end
+  end
+
+  class BadRequestError < StandardError
+    include ProblemDetails
+    def title
+      'Bad Request'
+    end
+    def status
+      400
+    end
+  end
+  class NotFoundError < StandardError
+    include ProblemDetails
+    def title
+      'Not Found'
+    end
+    def status
+      404
+    end
+  end
+  class InternalServerError < StandardError
+    include ProblemDetails
+    def title
+      'Internal Server Error'
+    end
+    def status
+      500
+    end
+  end
+
   DEFAULT_PATH = 'pcdm?wt=json&q=id:'
   ID_PREFIX = "fcrepo:"
   FCREPO_URL = Rails.application.config.fcrepo_url
@@ -12,14 +52,15 @@ module ManifestHelper
   MANIFEST_URL = Rails.application.config.iiif_manifest_url
   SOLR_URL = Rails.application.config.solr_url
   HTTP_CONN = Faraday.new(ssl: {verify: false}, request: {params_encoder: Faraday::FlatParamsEncoder}) do |faraday|
-    faraday.response :json
+    faraday.response :json, content_type: /\bjson$/
     faraday.adapter Faraday.default_adapter
   end
   MANIFEST_LEVEL = ['issue', 'letter', 'image', 'reel']
   CANVAS_LEVEL = ['page']
+  HTTP_ERRORS = [BadRequestError, NotFoundError, InternalServerError]
 
   def verify_prefix(id)
-    raise "Missing prefix: " + ID_PREFIX unless id.starts_with?(ID_PREFIX)
+    raise NotFoundError, "Identifier #{id} is missing prefix #{ID_PREFIX}" unless id.starts_with?(ID_PREFIX)
   end
 
   def encode(str)
@@ -39,6 +80,7 @@ module ManifestHelper
   end
 
   def get_path(id)
+    raise NotFoundError, "URI #{id} does not have a recognized base URI" unless id.start_with? FCREPO_URL
     id[FCREPO_URL.length..id.length]
   end
 
@@ -56,10 +98,15 @@ module ManifestHelper
 
   def get_solr_doc(id)
     doc_id = id_to_uri(id)
-    response = HTTP_CONN.get get_solr_url(doc_id)
-    raise "Got #{response.status} for #{SOLR_URL + DEFAULT_PATH + quote(doc_id)}" unless response.success?
+    solr_url = get_solr_url(doc_id)
+    begin
+      response = HTTP_CONN.get solr_url
+    rescue Faraday::ConnectionFailed => e
+      raise InternalServerError, "Unable to connect to Solr"
+    end
+    raise InternalServerError, "Got a #{response.status} response from Solr" unless response.success?
     doc = response.body["response"]["docs"][0]
-    raise "No results for #{SOLR_URL + DEFAULT_PATH + quote(doc_id)}" if doc.nil?
+    raise NotFoundError, "No Solr document with id #{doc_id}" if doc.nil?
     doc.with_indifferent_access
   end
 
@@ -89,7 +136,7 @@ module ManifestHelper
     res = HTTP_CONN.get SOLR_URL + "select", solr_params
     ocr_field = 'extracted_text'
     annotations = []
-    results = JSON.parse(res.body)
+    results = res.body
     highlight_pattern = /<em>([^<]*)<\/em>/
     coord_pattern = /(\d+,\d+,\d+,\d+)/
     annotation_list_uri = base_uri + '/list/' + uri_to_id(canvas_uri) + '?q=' + encode(query)
@@ -145,7 +192,7 @@ module ManifestHelper
     }
     res = HTTP_CONN.get SOLR_URL + "select", solr_params
     annotations = []
-    results = JSON.parse(res.body)
+    results = res.body
     coord_tag_pattern = /\|(\d+,\d+,\d+,\d+)/
     annotation_list_uri = base_uri + '/list/' + uri_to_id(canvas_uri)
 

--- a/app/controllers/manifests_controller.rb
+++ b/app/controllers/manifests_controller.rb
@@ -9,16 +9,20 @@ class ManifestsController < ApplicationController
   # GET /manifests/:id
   def show
     prefixed_id = params[:id]
-    verify_prefix(prefixed_id)
-    @doc = get_solr_doc(prefixed_id)
-    if is_manifest_level? @doc[:component]
-      prepare_for_render(@doc, params[:q])
-      render :show
-    elsif is_canvas_level? @doc[:component]
-      page_id = get_prefixed_id(get_path(@doc[:page_issue]))
-      redirect_to manifest_url(id: page_id, q: params[:q]), status: :see_other
-    else
-      raise ActionController::RoutingError.new('Not an PCDM Object/File: ' + prefixed_id)
+    begin
+      verify_prefix(prefixed_id)
+      @doc = get_solr_doc(prefixed_id)
+      if is_manifest_level? @doc[:component]
+        prepare_for_render(@doc, params[:q])
+        render :show
+      elsif is_canvas_level? @doc[:component]
+        page_id = get_prefixed_id(get_path(@doc[:page_issue]))
+        redirect_to manifest_url(id: page_id, q: params[:q]), status: :see_other
+      else
+        raise BadRequestError, "Resource #{prefixed_id} does not have a recognized manifest or canvas type"
+      end
+    rescue *HTTP_ERRORS => e
+      render json: e.to_h, status: e.status
     end
   end
 
@@ -26,14 +30,18 @@ class ManifestsController < ApplicationController
   def show_list
     prefix, path = params[:id].split /:/
     manifest_id = "#{prefix}:#{encode(path)}"
-    verify_prefix(manifest_id)
-    canvas_id = params[:list_id]
-    verify_prefix(canvas_id)
-    if params[:q]
-      render json: get_highlighted_hits(manifest_id, id_to_uri(canvas_id), params[:q])
-    else
-      # text block sc:painting annotations
-      render json: get_textblock_list(manifest_id, id_to_uri(canvas_id))
+    begin
+      verify_prefix(manifest_id)
+      canvas_id = params[:list_id]
+      verify_prefix(canvas_id)
+      if params[:q]
+        render json: get_highlighted_hits(manifest_id, id_to_uri(canvas_id), params[:q])
+      else
+        # text block sc:painting annotations
+        render json: get_textblock_list(manifest_id, id_to_uri(canvas_id))
+      end
+    rescue *HTTP_ERRORS => e
+      render json: e.to_h, status: e.status
     end
   end
 end


### PR DESCRIPTION
Added custom exception classes that support a to_h method so that they can be converted to JSON Problem Details responses (see RFC 7807).

https://issues.umd.edu/browse/LIBIIIF-58