### PR TITLE
LIBIIIF-69 Add citation field to manifest metadata

### DIFF
--- a/app/views/manifests/show.json.jb
+++ b/app/views/manifests/show.json.jb
@@ -53,7 +53,8 @@ json = {
     {'label': 'Date', 'value': @doc[:date]},
     {'label': 'Edition', 'value': @doc[:issue_edition]},
     {'label': 'Volume', 'value': @doc[:issue_volume]},
-    {'label': 'Issue', 'value': @doc[:issue_issue]}
+    {'label': 'Issue', 'value': @doc[:issue_issue]},
+    {'label': 'Bibliographic Citation', 'value': @doc[:citation]}
   ],
   'thumbnail': {
     '@id': @doc[:thumbnail_id],

--- a/app/views/manifests/show.json.jb
+++ b/app/views/manifests/show.json.jb
@@ -54,7 +54,7 @@ json = {
     {'label': 'Edition', 'value': @doc[:issue_edition]},
     {'label': 'Volume', 'value': @doc[:issue_volume]},
     {'label': 'Issue', 'value': @doc[:issue_issue]},
-    {'label': 'Bibliographic Citation', 'value': @doc[:citation]}
+    {'label': 'Bibliographic Citation', 'value': @doc[:citation].join(' ')}
   ],
   'thumbnail': {
     '@id': @doc[:thumbnail_id],


### PR DESCRIPTION
This adds the citation field to the metadata secion.
Requires that solr is using an updated solconfig.xml that includes the
citation field in the pcdm request handler.

https://issues.umd.edu/browse/LIBIIIF-69