### PR TITLE
LIBIIIF-75. Guard against a nil bibliographic citation field.

### DIFF
--- a/app/controllers/concerns/manifest_helper.rb
+++ b/app/controllers/concerns/manifest_helper.rb
@@ -242,6 +242,7 @@ module ManifestHelper
     doc[:rights] = doc[:rights].is_a?(Array) ? doc[:rights][0] : doc[:rights]
     doc[:date] = doc[:display_date] || doc[:date].sub(/T.*/, '')
     doc[:pages] = doc[:pages][:docs]
+    doc[:citation] = doc[:citation].join(' ') if doc[:citation]
     doc[:pages].each do |page|
       image = get_image(doc, page[:id])
       page_id = get_path(page[:id])

--- a/app/views/manifests/show.json.jb
+++ b/app/views/manifests/show.json.jb
@@ -54,7 +54,7 @@ json = {
     {'label': 'Edition', 'value': @doc[:issue_edition]},
     {'label': 'Volume', 'value': @doc[:issue_volume]},
     {'label': 'Issue', 'value': @doc[:issue_issue]},
-    {'label': 'Bibliographic Citation', 'value': @doc[:citation].join(' ')}
+    {'label': 'Bibliographic Citation', 'value': @doc[:citation]}
   ],
   'thumbnail': {
     '@id': @doc[:thumbnail_id],


### PR DESCRIPTION
Only attempt to join the bibliographic citation field if it is present.

https://issues.umd.edu/browse/LIBIIIF-75