### PR TITLE
LIBIIIF-74. Separate out fcrepo-specific code.

### DIFF
--- a/app/controllers/concerns/fcrepo_helper.rb
+++ b/app/controllers/concerns/fcrepo_helper.rb
@@ -1,0 +1,241 @@
+require 'faraday'
+require 'faraday_middleware'
+
+module FcrepoHelper
+  extend ActiveSupport::Concern
+
+  DEFAULT_PATH = 'pcdm?wt=json&q=id:'
+  ID_PREFIX = "fcrepo:"
+  FCREPO_URL = Rails.application.config.fcrepo_url
+  IMAGE_URL = Rails.application.config.iiif_image_url
+  MANIFEST_URL = Rails.application.config.iiif_manifest_url
+  SOLR_URL = Rails.application.config.solr_url
+  HTTP_CONN = Faraday.new(ssl: {verify: false}, request: {params_encoder: Faraday::FlatParamsEncoder}) do |faraday|
+    faraday.response :json, content_type: /\bjson$/
+    faraday.adapter Faraday.default_adapter
+  end
+
+  DEFAULT_IIIF_PARAMS = {
+    region: 'full',
+    size: 'full',
+    rotation: 0,
+    quality: 'default',
+    format: 'jpg'
+  }
+  def iiif_image_uri(image, param={})
+    uri = IMAGE_URL + image.id
+    unless param.empty?
+      p = DEFAULT_IIIF_PARAMS.merge(param)
+      uri += "/#{p[:region]}/#{p[:size]}/#{p[:rotation]}/#{p[:quality]}.#{p[:format]}"
+    end
+    uri
+  end
+
+  def get_formatted_id(path)
+    ID_PREFIX + path.gsub('/', '%2F')
+  end
+
+  def get_path(uri)
+    path = uri[FCREPO_URL.length..uri.length]
+    path.gsub('/', ':').gsub /:(..):(..):(..):(..):\1\2\3\4/, '::\1\2\3\4'
+  end
+
+  def path_to_uri(path)
+    if m = path.match(/^([^:]+)::((..)(..)(..)(..).*)/)
+      pairtree = m[3..6].join('/')
+      path = "#{m[1]}/#{pairtree}/#{m[2]}"
+    end
+    FCREPO_URL + path.gsub(':', '/')
+  end
+
+  MANIFEST_LEVEL = ['issue', 'letter', 'image', 'reel']
+  CANVAS_LEVEL = ['page']
+
+  class FcrepoPage
+    include ManifestHelper
+    include FcrepoHelper
+    attr_reader :id, :number, :image, :uri
+
+    def initialize(doc, page_doc)
+      @uri = page_doc[:id]
+      @id = get_formatted_id(get_path(@uri))
+      @number = page_doc[:page_number]
+
+      doc[:images][:docs].each do |image_doc|
+        if image_doc[:pcdm_file_of] == @uri
+          @image = FcrepoImage.new(image_doc)
+        end
+      end
+    end
+  end
+
+  class FcrepoImage
+    include ManifestHelper
+    include FcrepoHelper
+    attr_reader :id, :width, :height, :uri
+
+    def initialize(image_doc)
+      @uri = image_doc[:id]
+      @id = get_formatted_id(get_path(@uri))
+      @width = image_doc[:image_width]
+      @height = image_doc[:image_height]
+    end
+  end
+
+  class FcrepoItem
+    include ManifestHelper
+    include FcrepoHelper
+
+    def initialize(path, query)
+      @path = path
+      @query = query
+      @uri = path_to_uri(@path)
+      # base URI of the manifest resources
+      @base_uri = MANIFEST_URL + get_formatted_id(@path) + '/'
+    end
+
+    def component
+      doc[:component]
+    end
+
+    def is_manifest_level?
+      return false unless component
+      MANIFEST_LEVEL.include? component.downcase
+    end
+
+    def is_canvas_level?
+      return false unless component
+      CANVAS_LEVEL.include? component.downcase
+    end
+
+    def doc
+      return @doc if @doc
+
+      begin
+        response = HTTP_CONN.get SOLR_URL + "pcdm", q: "id:#{@uri.gsub(':', '\:')}", wt: 'json'
+      rescue Faraday::ConnectionFailed => e
+        raise InternalServerError, "Unable to connect to Solr"
+      end
+      raise InternalServerError, "Got a #{response.status} response from Solr" unless response.success?
+      doc = response.body["response"]["docs"][0]
+      raise NotFoundError, "No Solr document with id #{@uri}" if doc.nil?
+      @doc = doc.with_indifferent_access
+    end
+
+    def manifest_id
+      if is_manifest_level?
+        get_formatted_id(@uri)
+      else
+        get_formatted_id(get_path(doc[:page_issue]))
+      end
+    end
+
+    def pages
+      doc[:pages][:docs].map {|page_doc| FcrepoPage.new(doc, page_doc)}
+    end
+
+    def date
+      doc[:display_date] || doc[:date].sub(/T.*/, '')
+    end
+
+    def license
+      doc[:rights].is_a?(Array) ? doc[:rights][0] : doc[:rights]
+    end
+
+    def attribution
+      doc[:attribution]
+    end
+
+    def label
+      doc[:display_title]
+    end
+
+    def metadata
+      citation = doc[:citation] ? doc[:citation].join(' ') : nil
+      [
+        {'label': 'Date', 'value': date},
+        {'label': 'Edition', 'value': doc[:issue_edition]},
+        {'label': 'Volume', 'value': doc[:issue_volume]},
+        {'label': 'Issue', 'value': doc[:issue_issue]},
+        {'label': 'Bibliographic Citation', 'value': citation}
+      ].reject {|item| item[:value].nil? }
+    end
+
+    def get_highlighted_hits(page_id)
+      prefix, path = page_id.split /:/, 2
+      page_uri = path_to_uri(path)
+      solr_params = {
+        'fq'             => ['rdf_type:oa\:Annotation', "annotation_source:#{page_uri.gsub(':', '\:')}"],
+        'q'              => @query,
+        'wt'             => 'json',
+        'fl'             => '*',
+        'hl'             => 'true',
+        'hl.fl'          => 'extracted_text',
+        'hl.simple.pre'  => '<em>',
+        'hl.simple.post' => '</em>',
+        'hl.method'      => 'unified',
+      }
+      res = HTTP_CONN.get SOLR_URL + "select", solr_params
+      ocr_field = 'extracted_text'
+      annotations = []
+      results = res.body
+      highlight_pattern = /<em>([^<]*)<\/em>/
+      coord_pattern = /(\d+,\d+,\d+,\d+)/
+      annotation_list_uri = list_uri(get_formatted_id(path)) + '?q=' + encode(@query)
+      count = 0
+
+      docs = results['response']['docs']
+
+      snippets = results["highlighting"] || []
+      snippets.select { |uri, fields| fields[ocr_field] }.each do |uri, fields|
+        body = docs.select { |doc| doc['id'] == uri }.first
+        fields[ocr_field].each do |text|
+          text.scan highlight_pattern do |hit|
+            hit[0].scan coord_pattern do |coords|
+              count += 1
+              annotations.push(
+                annotation(
+                  id: "#search-result-%03d" % count,
+                  type: 'umd:searchResult',
+                  motivation: 'oa:highlighting',
+                  target: body['annotation_source'][0],
+                  selector: fragment_selector("xywh=#{coords[0]}")
+                )
+              )
+            end
+          end
+        end
+      end
+      annotation_list(annotation_list_uri, annotations)
+    end
+
+    def get_textblock_list(page_id)
+      prefix, path = page_id.split /:/, 2
+      page_uri = path_to_uri(path)
+      solr_params = {
+        'fq' => ['rdf_type:oa\:Annotation', "annotation_source:#{page_uri.gsub(':', '\:')}"],
+        'wt' => 'json',
+        'q' => '*:*',
+        'fl' => '*',
+        'rows' => 100,
+      }
+      res = HTTP_CONN.get SOLR_URL + "select", solr_params
+      results = res.body
+      coord_tag_pattern = /\|(\d+,\d+,\d+,\d+)/
+      annotation_list_uri = list_uri(get_formatted_id(path))
+
+      docs = results['response']['docs']
+      annotations = docs.map do |doc|
+        annotation(
+          id: '#' + doc['resource_selector'][0],
+          type: 'umd:articleSegment',
+          motivation: 'sc:painting',
+          text: doc['extracted_text'].gsub(coord_tag_pattern, ''),
+          target: doc['annotation_source'][0],
+          selector: fragment_selector(doc['resource_selector'][0])
+        )
+      end
+      annotation_list(annotation_list_uri, annotations)
+    end
+  end
+end

--- a/app/controllers/concerns/manifest_helper.rb
+++ b/app/controllers/concerns/manifest_helper.rb
@@ -1,5 +1,3 @@
-require 'faraday'
-require 'faraday_middleware'
 require 'erb'
 
 module ManifestHelper
@@ -26,6 +24,7 @@ module ManifestHelper
       400
     end
   end
+
   class NotFoundError < StandardError
     include ProblemDetails
     def title
@@ -35,6 +34,7 @@ module ManifestHelper
       404
     end
   end
+
   class InternalServerError < StandardError
     include ProblemDetails
     def title
@@ -45,132 +45,13 @@ module ManifestHelper
     end
   end
 
-  DEFAULT_PATH = 'pcdm?wt=json&q=id:'
-  ID_PREFIX = "fcrepo:"
-  FCREPO_URL = Rails.application.config.fcrepo_url
-  IMAGE_URL = Rails.application.config.iiif_image_url
-  MANIFEST_URL = Rails.application.config.iiif_manifest_url
-  SOLR_URL = Rails.application.config.solr_url
-  HTTP_CONN = Faraday.new(ssl: {verify: false}, request: {params_encoder: Faraday::FlatParamsEncoder}) do |faraday|
-    faraday.response :json, content_type: /\bjson$/
-    faraday.adapter Faraday.default_adapter
-  end
-  MANIFEST_LEVEL = ['issue', 'letter', 'image', 'reel']
-  CANVAS_LEVEL = ['page']
-  HTTP_ERRORS = [BadRequestError, NotFoundError, InternalServerError]
-
-  def verify_prefix(id)
-    raise NotFoundError, "Identifier #{id} is missing prefix #{ID_PREFIX}" unless id.starts_with?(ID_PREFIX)
-  end
-
   def encode(str)
     ERB::Util.url_encode(str)
   end
 
-  def get_formatted_id(id)
-    ID_PREFIX + encode(id)
-  end
+  HTTP_ERRORS = [BadRequestError, NotFoundError, InternalServerError]
 
-  def get_prefixed_id(id)
-    ID_PREFIX + id
-  end
-
-  def quote(str)
-    '"' + str + '"'
-  end
-
-  def get_path(id)
-    raise NotFoundError, "URI #{id} does not have a recognized base URI" unless id.start_with? FCREPO_URL
-    id[FCREPO_URL.length..id.length]
-  end
-
-  def get_solr_url(id)
-    SOLR_URL + DEFAULT_PATH + quote(id)
-  end
-
-  def id_to_uri(id)
-    FCREPO_URL + id[ID_PREFIX.length..id.length]
-  end
-
-  def uri_to_id(uri)
-    get_formatted_id(get_path(uri))
-  end
-
-  def get_solr_doc(id)
-    doc_id = id_to_uri(id)
-    solr_url = get_solr_url(doc_id)
-    begin
-      response = HTTP_CONN.get solr_url
-    rescue Faraday::ConnectionFailed => e
-      raise InternalServerError, "Unable to connect to Solr"
-    end
-    raise InternalServerError, "Got a #{response.status} response from Solr" unless response.success?
-    doc = response.body["response"]["docs"][0]
-    raise NotFoundError, "No Solr document with id #{doc_id}" if doc.nil?
-    doc.with_indifferent_access
-  end
-
-  def is_manifest_level?(component)
-    return false unless component
-    MANIFEST_LEVEL.include? component.downcase
-  end
-
-  def is_canvas_level?(component)
-    return false unless component
-    CANVAS_LEVEL.include? component.downcase
-  end
-
-  def get_highlighted_hits(manifest_id, canvas_uri, query)
-    base_uri = MANIFEST_URL + manifest_id
-    solr_params = {
-      'fq'             => ['rdf_type:oa\:Annotation', "annotation_source:#{canvas_uri.gsub(':', '\:')}"],
-      'q'              => query,
-      'wt'             => 'json',
-      'fl'             => '*',
-      'hl'             => 'true',
-      'hl.fl'          => 'extracted_text',
-      'hl.simple.pre'  => '<em>',
-      'hl.simple.post' => '</em>',
-      'hl.method'      => 'unified',
-    }
-    res = HTTP_CONN.get SOLR_URL + "select", solr_params
-    ocr_field = 'extracted_text'
-    annotations = []
-    results = res.body
-    highlight_pattern = /<em>([^<]*)<\/em>/
-    coord_pattern = /(\d+,\d+,\d+,\d+)/
-    annotation_list_uri = base_uri + '/list/' + uri_to_id(canvas_uri) + '?q=' + encode(query)
-    count = 0
-
-    docs = results['response']['docs']
-
-    snippets = results["highlighting"] || []
-    snippets.select { |uri, fields| fields[ocr_field] }.each do |uri, fields|
-      body = docs.select { |doc| doc['id'] == uri }.first
-      fields[ocr_field].each do |text|
-        text.scan highlight_pattern do |hit|
-          hit[0].scan coord_pattern do |coords|
-            count += 1
-            annotations.push({
-              "@id" => "#search-result-%03d" % count,
-              "@type" => ["oa:Annotation", "umd:searchResult"],
-              "on" => {
-                "@type" => "oa:SpecificResource",
-                "selector" => {
-                  "@type" => "oa:FragmentSelector",
-                  "value" => "xywh=#{coords[0]}"
-                },
-                "full" => body['annotation_source'][0]
-              },
-              "motivation" => "oa:highlighting"
-            })
-          end
-        end
-      end
-    end
-
-    annotation_list(annotation_list_uri, annotations)
-  end
+  # generic mixin methods
 
   def annotation_list(uri, annotations)
     {
@@ -181,105 +62,140 @@ module ManifestHelper
     }
   end
 
-  def get_textblock_list(manifest_id, canvas_uri)
-    base_uri = MANIFEST_URL + manifest_id
-    solr_params = {
-      'fq'             => ['rdf_type:oa\:Annotation', "annotation_source:#{canvas_uri.gsub(':', '\:')}"],
-      'wt'             => 'json',
-      'q' => '*:*',
-      'fl'             => '*',
-      'rows' => 100,
-    }
-    res = HTTP_CONN.get SOLR_URL + "select", solr_params
-    annotations = []
-    results = res.body
-    coord_tag_pattern = /\|(\d+,\d+,\d+,\d+)/
-    annotation_list_uri = base_uri + '/list/' + uri_to_id(canvas_uri)
+  def canvases
+    canvases = []
+    pages.map do |page|
+      image = page.image
+      {
+        '@id': canvas_uri(page.id),
+        '@type': 'sc:Canvas',
+        'label': "Page #{page.number}",
+        'height': image.height,
+        'width': image.width,
 
-    docs = results['response']['docs']
-    docs.each do |doc|
-      annotations.push({
-        '@id' => '#' + doc['resource_selector'][0],
-        "@type" => ["oa:Annotation", "umd:articleSegment"],
-        "on" => {
-          "@type" => "oa:SpecificResource",
-          "selector" => {
-            "@type" => "oa:FragmentSelector",
-            "value" => doc['resource_selector'][0]
-          },
-          "full" => doc['annotation_source'][0]
-        },
-        "resource" => [
+        'images': [
           {
-            "@type" => "cnt:ContentAsText",
-            "format" => "text/plain",
-            "chars" => doc['extracted_text'].gsub(coord_tag_pattern, '')
+            '@id': annotation_uri(image.id),
+            '@type': 'oa:Annotation',
+            'motivation': 'sc:painting',
+            'resource': {
+              '@id': iiif_image_uri(image),
+              '@type': 'dctypes:Image',
+              'format': 'image/jpeg',
+              'service': {
+                '@context': 'http://iiif.io/api/image/2/context.json',
+                '@id': iiif_image_uri(image),
+                'profile': 'http://iiif.io/api/image/2/profiles/level2.json'
+              },
+              'height': image.height,
+              'width': image.width,
+            },
+            'on': canvas_uri(page.id)
           }
         ],
-        "motivation" => "sc:painting"
-      })
-    end
-    annotation_list(annotation_list_uri, annotations)
-  end
-
-  def get_image(doc, page_id)
-    doc[:images][:docs].each do |image|
-      if page_id == image[:pcdm_file_of]
-        return image
+        'otherContent': [
+          {
+            '@id': list_uri(page.id),
+            '@type': 'sc:AnnotationList'
+          }
+        ]
+      }.tap do |canvas|
+        if @query
+          canvas[:otherContent].push({
+            '@id': list_uri(page.id) + '?q=' + encode(@query),
+            '@type': 'sc:AnnotationList',
+          })
+        end
       end
     end
   end
 
-  def canvas_length(length)
-    return 1200 if length.nil?
-    return 2 * length if length <= 1200
-    length
+  def manifest
+    first_page = pages[0]
+    first_image = first_page.image
+
+    {
+      '@context': 'http://iiif.io/api/presentation/2/context.json',
+      '@id': manifest_uri,
+      '@type': 'sc:Manifest',
+
+      'label': label,
+      'metadata': metadata,
+      'thumbnail': {
+        '@id': iiif_image_uri(first_image, size: '80,100'),
+        'service': {
+          '@context': 'http://iiif.io/api/image/2/context.json',
+          '@id': iiif_image_uri(first_image),
+          'profile': 'http://iiif.io/api/image/2/level1.json'
+        }
+      },
+      'navDate': date,
+      'license': license,
+      'attribution': attribution,
+
+      'logo': {
+        '@id': 'https://www.lib.umd.edu/images/wrapper/liblogo.png'
+      },
+
+      'sequences': [
+        {
+          '@id': sequence_uri('normal'),
+          '@type': 'sc:Sequence',
+          'label': 'Current Page Order',
+          'startCanvas': canvas_uri(first_page.id),
+          'canvases': canvases
+        }
+      ]
+    }
   end
 
-  def add_page_info(doc, query)
-    issue_id = get_path(doc[:id])
-    base_id = MANIFEST_URL + get_formatted_id(issue_id)
-    doc[:rights] = doc[:rights].is_a?(Array) ? doc[:rights][0] : doc[:rights]
-    doc[:date] = doc[:display_date] || doc[:date].sub(/T.*/, '')
-    doc[:pages] = doc[:pages][:docs]
-    doc[:citation] = doc[:citation].join(' ') if doc[:citation]
-    doc[:pages].each do |page|
-      image = get_image(doc, page[:id])
-      page_id = get_path(page[:id])
-      image_id = get_path(image[:id])
-      page[:canvas_height] = canvas_length(image[:image_height])
-      page[:canvas_width] = canvas_length(image[:image_width])
-      page[:image_height] = image[:image_height]
-      page[:image_width] = image[:image_width]
-      page[:image_mime_type] = image[:mime_type]
-      page[:canvas_id] = base_id + '/canvas/' + get_formatted_id(page_id)
-      page[:image_id] = base_id + '/annotation/' + get_formatted_id(image_id)
-      page[:resource_id] = IMAGE_URL + get_formatted_id(image_id)
-      page[:search_hits_list] = query ? base_id + '/list/' + get_formatted_id(page_id) + '?q=' + encode(query) : nil
-      page[:textblocks_list] = base_id + '/list/' + get_formatted_id(page_id)
+  def manifest_uri
+    @base_uri + 'manifest'
+  end
+
+  def canvas_uri(page_id)
+    @base_uri + 'canvas/' + page_id
+  end
+
+  def annotation_uri(doc_id)
+    @base_uri + 'annotation/' + doc_id
+  end
+
+  def list_uri(page_id)
+    @base_uri + 'list/' + page_id
+  end
+
+  def sequence_uri(label)
+    @base_uri + 'sequence/' + label
+  end
+
+  def fragment_selector(value)
+    {
+      "@type" => "oa:FragmentSelector",
+      "value" => value
+    }
+  end
+
+  def annotation(param = {})
+    {
+      '@id' => param[:id],
+      "@type" => ["oa:Annotation", param[:type]],
+      "on" => {
+        "@type" => "oa:SpecificResource",
+        "selector" => param[:selector],
+        "full" => param[:target]
+      },
+      "motivation" => param[:motivation]
+    }.tap do |anno|
+      if param[:text]
+        anno['resource'] = [
+          {
+            "@type" => "cnt:ContentAsText",
+            "format" => "text/plain",
+            "chars" => param[:text]
+          }
+        ]
+      end
     end
-  end
-
-  def add_thumbnail_info(doc)
-    return if doc[:pages].empty?
-    first_image_resource_id = doc[:pages][0][:resource_id]
-    doc[:thumbnail_service_id] = first_image_resource_id
-    doc[:thumbnail_id] = first_image_resource_id + '/full/80,100/0/default.jpg'
-  end
-
-  def add_sequence_info(doc)
-    return if doc[:pages].empty?
-    issue_id = get_path(doc[:id])
-    first_page_id = get_path(doc[:pages][0][:id])
-    sequence_base = MANIFEST_URL + get_formatted_id(issue_id)
-    doc[:sequence_id] =  sequence_base + '/sequence/normal'
-    doc[:start_canvas] = sequence_base + '/canvas/' + get_formatted_id(first_page_id)
-  end
-
-  def prepare_for_render(doc, query)
-    add_page_info(doc, query)
-    add_thumbnail_info(doc)
-    add_sequence_info(doc)
-    doc.delete(:images)
   end
 end


### PR DESCRIPTION
Created an fcrepo_helper module that encapsulates the fcrepo-specific code for generating IIIF manifests. Only the generic code to generate manifests remains in the manifest_helper module.

Additional features:
* Escape slashes when going from path to URI.
* Implement a pairtree-shortening identifier syntax: pcdm/01/23/45/67/01234567-... -> pcdm::01234567-...

https://issues.umd.edu/browse/LIBIIIF-74