### PR TITLE
LIBIIIF-81. Manifest request errors out on missing date.

### DIFF
--- a/lib/iiif/fcrepo.rb
+++ b/lib/iiif/fcrepo.rb
@@ -121,7 +121,7 @@ module IIIF
       end
 
       def date
-        doc[:display_date] || doc[:date].sub(/T.*/, '')
+        doc[:display_date] || (doc[:date].sub(/T.*/, '') if doc[:date])
       end
 
       def license


### PR DESCRIPTION
https://issues.umd.edu/browse/LIBIIIF-81