### PR TITLE
LIBIIIF-78. Ensure the manifest is compliant with the IIIF Presentation API.

### DIFF
--- a/lib/iiif/fcrepo.rb
+++ b/lib/iiif/fcrepo.rb
@@ -120,8 +120,8 @@ module IIIF
         doc[:pages][:docs].map {|page_doc| get_page(doc, page_doc)}
       end
 
-      def date
-        doc[:display_date] || (doc[:date].sub(/T.*/, '') if doc[:date])
+      def nav_date
+        doc[:date]
       end
 
       def license
@@ -138,8 +138,9 @@ module IIIF
 
       def metadata
         citation = doc[:citation] ? doc[:citation].join(' ') : nil
+        display_date = doc[:display_date] || (doc[:date].sub(/T.*/, '') if doc[:date])
         [
-          {'label': 'Date', 'value': date},
+          {'label': 'Date', 'value': display_date},
           {'label': 'Edition', 'value': doc[:issue_edition]},
           {'label': 'Volume', 'value': doc[:issue_volume]},
           {'label': 'Issue', 'value': doc[:issue_issue]},

--- a/lib/iiif/fedora2.rb
+++ b/lib/iiif/fedora2.rb
@@ -39,6 +39,10 @@ module IIIF
         false
       end
 
+      def label
+        @pid
+      end
+
       def pages
         if @service
           # only one page; @pid is the image PID

--- a/lib/iiif_base.rb
+++ b/lib/iiif_base.rb
@@ -34,7 +34,7 @@ module IIIF
     def label
     end
 
-    def date
+    def nav_date
     end
 
     def license
@@ -44,7 +44,16 @@ module IIIF
     end
 
     def metadata
-      {}
+      []
+    end
+
+    def description
+    end
+
+    def viewing_direction
+    end
+
+    def viewing_hint
     end
 
     def annotation_list(uri, annotations)
@@ -86,6 +95,7 @@ module IIIF
               'on' => canvas_uri(page.id)
             }
           ],
+          'thumbnail' => thumbnail(image),
           'otherContent' => other_content(page)
         }
       end
@@ -115,27 +125,23 @@ module IIIF
         '@type' => 'sc:Manifest',
         'label' => label,
         'metadata' => metadata,
-        'navDate' => date,
-        'license' => license,
-        'attribution' => attribution,
         'sequences' => [],
         'thumbnail' => {},
         'logo' => {
           '@id' => 'https://www.lib.umd.edu/images/wrapper/liblogo.png'
         }
       }.tap do |manifest|
+        manifest['navDate'] = nav_date if nav_date
+        manifest['license'] = license if license
+        manifest['attribution'] = attribution if attribution
+        manifest['description'] = description if description
+        manifest['viewing_direction'] = viewing_direction if viewing_direction
+        manifest['viewing_hint'] = viewing_hint if viewing_hint
         if pages.length > 0
           first_page = pages[0]
           first_image = first_page.image
 
-          manifest['thumbnail'] = {
-            '@id' => image_uri(first_image.id, size: '80,100'),
-            'service' => {
-              '@context' => 'http://iiif.io/api/image/2/context.json',
-              '@id' => image_uri(first_image.id),
-              'profile' => 'http://iiif.io/api/image/2/level1.json'
-            }
-          }
+          manifest['thumbnail'] = thumbnail(first_image)
           manifest['sequences'] = [
             {
               '@id' => sequence_uri('normal'),
@@ -147,6 +153,22 @@ module IIIF
           ]
         end
       end
+    end
+
+    def thumbnail(image)
+      width = 80
+      height = 100
+      {
+        '@id' => image_uri(image.id, size: "#{width},#{height}"),
+        'service' => {
+          '@context' => 'http://iiif.io/api/image/2/context.json',
+          '@id' => image_uri(image.id),
+          'profile' => 'http://iiif.io/api/image/2/level1.json'
+        },
+        'format' => 'image/jpeg',
+        'width' => width,
+        'height' => height
+      }
     end
 
     def manifest_uri


### PR DESCRIPTION
* navDate must be a datetime
* added optional description, viewing_direction, and viewing_hint fields
* made nav_date, license, and attribution optional (they only show up if they have a non-null value)
* default metadata value is an empty array
* use the PID as the label for the fedora2 manifests
* include width, height, and format of thumbnails

https://issues.umd.edu/browse/LIBIIIF-78