### PR TITLE
LIBIIIF-80. Restore default canvas and image dimensions.

### DIFF
--- a/lib/iiif_base.rb
+++ b/lib/iiif_base.rb
@@ -10,6 +10,8 @@ module IIIF
   end
 
   class Item
+    DEFAULT_CANVAS_HEIGHT = 1200
+    DEFAULT_CANVAS_WIDTH = 1200
 
     def encode(str)
       ERB::Util.url_encode(str)
@@ -72,8 +74,8 @@ module IIIF
           '@id' => canvas_uri(page.id),
           '@type' => 'sc:Canvas',
           'label' => page.label,
-          'height' => image.height,
-          'width' => image.width,
+          'height' => image.height || DEFAULT_CANVAS_HEIGHT,
+          'width' => image.width || DEFAULT_CANVAS_WIDTH,
 
           'images' => [
             {
@@ -89,8 +91,8 @@ module IIIF
                   '@id' => image_uri(image.id),
                   'profile' => 'http://iiif.io/api/image/2/profiles/level2.json'
                 },
-                'height' => image.height,
-                'width' => image.width,
+                'height' => image.height || DEFAULT_CANVAS_HEIGHT,
+                'width' => image.width || DEFAULT_CANVAS_WIDTH,
               },
               'on' => canvas_uri(page.id)
             }


### PR DESCRIPTION
Default if the image width or height is not available is 1200. This may result in square thumbnails when there is no dimension metadata on the objects, but that is preferable to broken images.

https://issues.umd.edu/browse/LIBIIIF-80