### PR TITLE
LIBIIIF-6. For missing fcrepo images, use the "static:unavailable" image.

### DIFF
--- a/config/iiif.yml
+++ b/config/iiif.yml
@@ -15,7 +15,7 @@ vagrant:
         fcrepo_url: https://fcrepolocal/fcrepo/rest/
         solr_url: https://solrlocal:8984/solr/fedora4/
         image_url: https://iiiflocal/images/
-        manifest_url: http://iiiflocal/manifests/
+        manifest_url: https://iiiflocal/manifests/
     fedora2:
         fedora2_url: http://fedoradev.lib.umd.edu/
         image_url: https://iiifdev.lib.umd.edu/images/

--- a/lib/iiif/fcrepo.rb
+++ b/lib/iiif/fcrepo.rb
@@ -102,6 +102,20 @@ module IIIF
               page.image = get_image(image_doc)
             end
           end
+
+          # NOTE: the more semantically correct solution to the problem of a
+          # missing image would be to return an empty images array and let the
+          # IIIF view handle displaying a placeholder. Unfortunately at this
+          # time Mirador does not support empty images arrays, so we have
+          # implemented the placeholder on the IIIF Presentation API side.
+          unless page.image
+            page.image = IIIF::Image.new.tap do |image|
+              image.uri = image_uri('static:unavailable', format: 'jpg')
+              image.id = 'static:unavailable'
+              image.width = 200
+              image.height = 200
+            end
+          end
         end
       end
 


### PR DESCRIPTION
https://issues.umd.edu/browse/LIBIIIF-6