### PR TITLE
LIBIIIF-89. Wrap annotation body resource in an array.

### DIFF
--- a/lib/iiif_base.rb
+++ b/lib/iiif_base.rb
@@ -223,7 +223,7 @@ module IIIF
         'on' => param[:target],
         'motivation' => param[:motivation]
       }.tap do |annotation|
-        annotation['resource'] = param[:body] if param[:body]
+        annotation['resource'] = [ param[:body] ] if param[:body]
       end
     end
 


### PR DESCRIPTION
Restores previous structure that Mirador was expecting.

https://issues.umd.edu/browse/LIBIIIF-89