### PR TITLE
LIBIIIF-90. Attempt to get image info for fedora2 PIDs from Solr.

### DIFF
--- a/config/iiif.yml
+++ b/config/iiif.yml
@@ -8,7 +8,8 @@ development:
         manifest_url: http://localhost:3000/manifests/
     fedora2:
         fedora2_url: http://fedoradev.lib.umd.edu/
-        solr_url: https://solrdev.lib.umd.edu/solr/fedora/select
+        solr_url: https://solrdev.lib.umd.edu/solr/fedora/
+        fcrepo_solr_url: https://solrdev.lib.umd.edu/solr/fedora4/
         image_url: https://iiifdev.lib.umd.edu/images/
         manifest_url: http://localhost:3000/manifests/
 vagrant:
@@ -19,7 +20,8 @@ vagrant:
         manifest_url: https://iiiflocal/manifests/
     fedora2:
         fedora2_url: http://fedoradev.lib.umd.edu/
-        solr_url: https://solrlocal:8984/solr/fedora/
+        solr_url: https://solrdev.lib.umd.edu/solr/fedora/
+        fcrepo_solr_url: https://solrdev.lib.umd.edu/solr/fedora4/
         image_url: https://iiifdev.lib.umd.edu/images/
         manifest_url: http://iiiflocal/manifests/
 production:
@@ -30,6 +32,7 @@ production:
         manifest_url: <%= ENV['IIIF_MANIFEST_URL'] %>
     fedora2:
         fedora2_url: <%= ENV['FEDORA2_URL'] %>
-        fedora2_url: <%= ENV['FEDORA2_SOLR_URL'] %>
+        solr_url: <%= ENV['FEDORA2_SOLR_URL'] %>
+        fcrepo_solr_url: <%= ENV['FCREPO_SOLR_URL'] %>
         image_url: <%= ENV['IIIF_IMAGE_URL'] %>
         manifest_url: <%= ENV['IIIF_MANIFEST_URL'] %>


### PR DESCRIPTION
Query the fcrepo Solr core pcdm request handler to try and get the image dimensions for all the images that are part of a given UMDM PID. If this doesn't work, fall back to the old (and slow) way of asking the image server for the info.json for each image. Added a config key for the fedora2 handler, fcrepo_solr_url, that is the URL of the fedora4 core to use. Modified code that queries Solr to assume that the URLs provided in config are to the core, so the application just appends the request handler name.

https://issues.umd.edu/browse/LIBIIIF-90