### PR TITLE
LIBIIIF-96. Sanity check when retrieving fedora2 metadata.

### DIFF
--- a/lib/iiif/fedora2.rb
+++ b/lib/iiif/fedora2.rb
@@ -148,7 +148,7 @@ module IIIF
       end
 
       def metadata
-        return {} unless doc
+        return {} unless doc && doc.include?('dmDate')
         # in the future we'll probably wanna get md from here..
         # we'll leave it on ice for now.
         # desc =  Nokogiri::XML(doc["umdm"])


### PR DESCRIPTION
Ensure that the dmDate key exists before trying to use it.

https://issues.umd.edu/browse/LIBIIIF-96