### PR TITLE
LIBIIIF-99 Allow METS item label to be optional

### DIFF
--- a/lib/iiif/fedora2.rb
+++ b/lib/iiif/fedora2.rb
@@ -106,31 +106,43 @@ module IIIF
           end
 
           # look up the METS relations in Fedora 2 to get a list of image PIDs
-          fptrs = mets.xpath(
-            '/mets:mets/mets:structMap[@TYPE="LOGICAL"]/mets:div[@ID="images"]//mets:div[@ID="DISPLAY"]/mets:fptr',
-            mets: METS_NAMESPACE
-          )
-          fptrs.map do |fptr|
-            label = fptr.xpath('../..').attribute('LABEL').value
-            fileid = fptr.attribute('FILEID').value
-            flocat = mets.at_xpath(
-              '/mets:mets/mets:fileSec/mets:fileGrp/mets:file[@ID=$id]/mets:FLocat',
-              { mets: METS_NAMESPACE },
-              id: fileid
-            )
-            pid = flocat.attribute('href').value
+          imgs = mets.xpath(
+                        '/mets:mets/mets:structMap[@TYPE="LOGICAL"]/mets:div[@ID="images"]/*[//mets:div[@ID="DISPLAY"]/mets:fptr]',
+                        mets: METS_NAMESPACE
+                            )
 
-            IIIF::Page.new.tap do |page|
-              page.id = get_formatted_id(pid)
-              page.label = label.empty? ? pid : label
-              page.image = IIIF::Image.new.tap do |image|
-                image.id = get_formatted_id(pid)
-                info = image_info_for.has_key?(pid) ? image_info_for[pid] : get_image_info(image_uri(image.id))
-                image.width = info['width']
-                image.height = info['height']
+          imgs.each_with_index.map do |img, order|
+            fptrs = img.xpath('.//mets:div[@ID="DISPLAY"]/mets:fptr', mets: METS_NAMESPACE)
+            fptrs.map do |fptr|
+              label = if img['LABEL']
+                        img['LABEL']
+                      elsif img['ORRDER']
+                        "Page #{img['ORDER']}"
+                      else
+                        "Page #{order + 1}"
+                      end
+
+              fileid = fptr.attribute('FILEID').value
+              flocat = mets.at_xpath(
+                '/mets:mets/mets:fileSec/mets:fileGrp/mets:file[@ID=$id]/mets:FLocat',
+                { mets: METS_NAMESPACE },
+                id: fileid
+              )
+              pid = flocat.attribute('href').value
+
+              IIIF::Page.new.tap do |page|
+                page.id = get_formatted_id(pid)
+                page.label = label.empty? ? pid : label
+                page.image = IIIF::Image.new.tap do |image|
+                  image.id = get_formatted_id(pid)
+                  info = image_info_for.key?(pid) ? image_info_for[pid] : get_image_info(image_uri(image.id))
+                  image.width = info['width']
+                  image.height = info['height']
+                end
               end
             end
-          end
+          end.flatten
+        
         end
       end
 

--- a/lib/iiif/fedora2.rb
+++ b/lib/iiif/fedora2.rb
@@ -116,8 +116,8 @@ module IIIF
             fptrs.map do |fptr|
               label = if img['LABEL']
                         img['LABEL']
-                      elsif img['ORRDER']
-                        "Page #{img['ORDER']}"
+                      elsif img['ORDER'] && img['ORDER'].strip =~ /^\d+$/
+                        "Page #{img['ORDER'].strip}"
                       else
                         "Page #{order + 1}"
                       end


### PR DESCRIPTION
Labels on METS fptr elements are optional, but the current pcdm-manifests code expects them to be there. The fix should be to apply a generic "Page N" label to any canvas where the METS data doesn't have a corresponding label, where N is that canvases 1-based index in the document order.

https://issues.umd.edu/browse/LIBIIIF-99