### PR TITLE
LIBIIIF-111. Added "archival record set" to manifest-level types.

### DIFF
--- a/lib/iiif/fcrepo.rb
+++ b/lib/iiif/fcrepo.rb
@@ -42,7 +42,7 @@ module IIIF
         path.gsub(':', '/')
       end
 
-      MANIFEST_LEVEL = ['issue', 'letter', 'image', 'reel']
+      MANIFEST_LEVEL = ['issue', 'letter', 'image', 'reel', 'archival record set']
       CANVAS_LEVEL = ['page']
 
       def initialize(path, query)


### PR DESCRIPTION
https://issues.umd.edu/browse/LIBIIIF-111