### PR TITLE
LIBIIIF-114. Look for image/* files, not just pcdmuse:PreservationMasterFile.

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,21 @@
+# URL of the fedora4 solr core
+SOLR_URL=http://solrlocal:8983/solr/fedora4/
+
+# URL of the fcrepo server
+FCREPO_URL=https://fcrepolocal/fcrepo/rest/
+
+# URL of the solr server, fedora4 core
+FCREPO_SOLR_URL=http://solrlocal:8983/solr/fedora4/
+
+# URL of the Fedora 2 server
+FEDORA2_URL=https://fedoradev.lib.umd.edu/
+
+# URL of the Fedora 2 solr core
+FEDORA2_SOLR_URL=https://solrdev.lib.umd.edu/solr/fedora/
+
+# URL of the IIIF image server
+# (N.B. requires the iiif-vagrant, which isn't currently functional)
+IIIF_IMAGE_URL=https://iiiflocal/images/
+
+# URL of this application
+IIIF_MANIFEST_URL=http://localhost:3000/manifests/

--- a/app/controllers/manifests_controller.rb
+++ b/app/controllers/manifests_controller.rb
@@ -11,10 +11,10 @@ class ManifestsController < ApplicationController
   # GET /manifests/:id/manifest
   def show
     begin
-      if item.is_manifest_level?
-        render json: item.manifest
-      elsif item.is_canvas_level?
+      if item.is_canvas_level?
         redirect_to_manifest item
+      elsif item.is_manifest_level?
+        render json: item.manifest
       else
         raise BadRequestError, "Resource #{params[:id]} does not have a recognized manifest or canvas type"
       end
@@ -26,7 +26,9 @@ class ManifestsController < ApplicationController
   # GET /manifests/:id/list/:list_id
   def show_list
     begin
-      if item.is_manifest_level?
+      if item.is_canvas_level?
+        redirect_to_manifest item
+      elsif item.is_manifest_level?
         if params[:q]
           raise NotFoundError, "No annotation list available" unless item.methods.include? :search_hit_list
           render json: item.search_hit_list(params[:list_id])
@@ -35,8 +37,6 @@ class ManifestsController < ApplicationController
           # text block sc:painting annotations
           render json: item.textblock_list(params[:list_id])
         end
-      elsif item.is_canvas_level?
-        redirect_to_manifest item
       else
         raise BadRequestError, "Resource #{params[:id]} does not have a recognized manifest or canvas type"
       end

--- a/config/application.rb
+++ b/config/application.rb
@@ -19,7 +19,5 @@ module PcdmManifests
     config.action_dispatch.default_headers = {
          'Access-Control-Allow-Origin' => '*'
     }
-
-    config.iiif = config_for(:iiif)
   end
 end

--- a/config/iiif.yml
+++ b/config/iiif.yml
@@ -1,18 +1,6 @@
 # base URLs for services
 # should end in '/'
-development:
-    fcrepo:
-        fcrepo_url: https://fcrepolocal/fcrepo/rest/
-        solr_url: http://solrlocal:8983/solr/fedora4/
-        image_url: https://iiiflocal/images/
-        manifest_url: http://localhost:3000/manifests/
-    fedora2:
-        fedora2_url: https://fedoradev.lib.umd.edu/
-        solr_url: https://solrdev.lib.umd.edu/solr/fedora/
-        fcrepo_solr_url: https://solrdev.lib.umd.edu/solr/fedora4/
-        image_url: https://iiifdev.lib.umd.edu/images/
-        manifest_url: http://localhost:3000/manifests/
-production:
+default: &default
     fcrepo:
         fcrepo_url: <%= ENV['FCREPO_URL'] %>
         solr_url: <%= ENV['SOLR_URL'] %>
@@ -24,3 +12,7 @@ production:
         fcrepo_solr_url: <%= ENV['FCREPO_SOLR_URL'] %>
         image_url: <%= ENV['IIIF_IMAGE_URL'] %>
         manifest_url: <%= ENV['IIIF_MANIFEST_URL'] %>
+development:
+    <<: *default
+production:
+    <<: *default

--- a/config/initializers/iiif.rb
+++ b/config/initializers/iiif.rb
@@ -1,0 +1,1 @@
+IIIF_CONFIG = PcdmManifests::Application.config_for(:iiif).with_indifferent_access

--- a/lib/iiif/fcrepo.rb
+++ b/lib/iiif/fcrepo.rb
@@ -9,8 +9,9 @@ module IIIF
       include HttpUtils
 
       PREFIX = "fcrepo"
-      CONFIG = Rails.configuration.iiif[PREFIX]
+      CONFIG = IIIF_CONFIG[PREFIX]
       SOLR_URL = CONFIG['solr_url']
+      PREFERRED_FORMATS = %w[image/tiff image/jpeg image/png image/gif]
 
       def image_base_uri
         CONFIG['image_url']
@@ -64,9 +65,13 @@ module IIIF
         doc[:component]
       end
 
+      def rdf_types
+        doc[:rdf_type]
+      end
+
       def is_manifest_level?
-        return false unless component
-        MANIFEST_LEVEL.include? component.downcase
+        return false unless rdf_types
+        rdf_types.include?('pcdm:Object') && !rdf_types.include?('pcdm:Collection')
       end
 
       def is_canvas_level?
@@ -77,7 +82,22 @@ module IIIF
       def doc
         return @doc if @doc
 
-        response = http_get(SOLR_URL + "pcdm", q: "id:#{@uri.gsub(':', '\:')}", wt: 'json')
+        response = http_get(
+          SOLR_URL + "pcdm",
+          q: "id:#{@uri.gsub(':', '\:')}",
+          wt: 'json',
+          fl: 'id,rdf_type,component,containing_issue,display_title,date,issue_edition,issue_volume,issue_issue,rights,pages:[subquery],citation,display_date,image_height,image_width,mime_type',
+          rows: 1,
+          'pages.q': '{!terms f=id v=$row.pcdm_members}',
+          'pages.fq': 'component:Page',
+          'pages.fl': 'id,display_title,page_number,images:[subquery]',
+          'pages.sort': 'page_number asc',
+          'pages.rows': '1000',
+          'pages.images.q': '{!terms f=id v=$row.pcdm_files}',
+          'pages.images.fl': 'id,pcdm_file_of,image_height,image_width,mime_type,display_title,rdf_type',
+          'pages.images.fq': 'mime_type:image/*',
+          'pages.images.rows': 1000
+        )
         doc = response.body["response"]["docs"][0]
         raise NotFoundError, "No Solr document with id #{@uri}" if doc.nil?
         @doc = doc.with_indifferent_access
@@ -91,35 +111,40 @@ module IIIF
         end
       end
 
+      def get_preferred_image(images)
+        images_by_type = Hash[images.map { |doc| [doc[:mime_type], doc] }]
+        PREFERRED_FORMATS.each do |mime_type|
+          return images_by_type[mime_type] if images_by_type.key? mime_type
+        end
+        nil
+      end
+
       def get_page(doc, page_doc)
         IIIF::Page.new.tap do |page|
           page.uri = page_doc[:id]
           page.id = get_formatted_id(get_path(page.uri))
           page.label = "Page #{page_doc[:page_number]}"
-
-          doc[:images][:docs].each do |image_doc|
-            if image_doc[:pcdm_file_of] == page.uri
-              page.image = get_image(image_doc)
-            end
-          end
-
-          # NOTE: the more semantically correct solution to the problem of a
-          # missing image would be to return an empty images array and let the
-          # IIIF view handle displaying a placeholder. Unfortunately at this
-          # time Mirador does not support empty images arrays, so we have
-          # implemented the placeholder on the IIIF Presentation API side.
-          unless page.image
-            page.image = IIIF::Image.new.tap do |image|
-              image.uri = image_uri('static:unavailable', format: 'jpg')
-              image.id = 'static:unavailable'
-              image.width = 200
-              image.height = 200
-            end
-          end
+          page.image = get_image(page_doc[:images])
         end
       end
 
-      def get_image(image_doc)
+      def get_image(images)
+        image_doc = get_preferred_image(images)
+
+        # NOTE: the more semantically correct solution to the problem of a
+        # missing image would be to return an empty images array and let the
+        # IIIF view handle displaying a placeholder. Unfortunately at this
+        # time Mirador does not support empty images arrays, so we have
+        # implemented the placeholder on the IIIF Presentation API side.
+        unless image_doc
+          return IIIF::Image.new.tap do |image|
+            image.uri = image_uri('static:unavailable', format: 'jpg')
+            image.id = 'static:unavailable'
+            image.width = 200
+            image.height = 200
+          end
+        end
+
         IIIF::Image.new.tap do |image|
           image.uri = image_doc[:id]
           # re-expand the path for image IDs that are destined for Loris

--- a/lib/iiif/fedora2.rb
+++ b/lib/iiif/fedora2.rb
@@ -7,7 +7,7 @@ module IIIF
       include HttpUtils
 
       PREFIX = 'fedora2'
-      CONFIG = Rails.configuration.iiif[PREFIX]
+      CONFIG = IIIF_CONFIG[PREFIX]
       METS_NAMESPACE = 'http://www.loc.gov/METS/'
 
       def image_base_uri


### PR DESCRIPTION
- modify the solr query
- reverse the canvas and manifest level checks
- anything that is pcdm:Object but not a pcdm:Collection qualifies as a manifest-level resource
- move configuration in the development environment into environment variables
- load IIIF config using an initializer

https://issues.umd.edu/browse/LIBIIIF-114