### PR TITLE
LIBIIIF-124. Reverse the manifest level/canvas level check for manifest_id.

### DIFF
--- a/lib/iiif/fcrepo.rb
+++ b/lib/iiif/fcrepo.rb
@@ -105,10 +105,10 @@ module IIIF
       end
 
       def manifest_id
-        if manifest_level?
-          get_formatted_id(@uri)
-        else
+        if canvas_level?
           get_formatted_id(get_path(doc[:containing_issue]))
+        else
+          get_formatted_id(@uri)
         end
       end
 


### PR DESCRIPTION
First check the more specific canvas level, then manifest level when determining what manifest id to return for the item. With the adoption of the Item content model, anything that is a canvas will also match the manifest level test.

https://issues.umd.edu/browse/LIBIIIF-124