### PR TITLE
LIBIIIF-140. Improvements for integrating with Canteloupe Image Server.

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,10 +1,7 @@
-# URL of the fedora4 solr core
-SOLR_URL=http://localhost:8983/solr/fedora4/
-
 # URL of the fcrepo server
-FCREPO_URL=http://localhost:8080/rest/
+FCREPO_URL=http://fcrepo-local:8080/fcrepo/rest/
 
-# URL of the solr server, fedora4 core
+# URL of the fcrepo solr core
 FCREPO_SOLR_URL=http://localhost:8983/solr/fedora4/
 
 # URL of the Fedora 2 server
@@ -14,8 +11,7 @@ FEDORA2_URL=https://fedoradev.lib.umd.edu/
 FEDORA2_SOLR_URL=https://solrdev.lib.umd.edu/solr/fedora/
 
 # URL of the IIIF image server
-# (N.B. requires the iiif-vagrant, which isn't currently functional)
-IIIF_IMAGE_URL=https://iiiflocal/images/
+IIIF_IMAGE_URL=http://localhost:8182/iiif/2/
 
 # URL of this application
-IIIF_MANIFEST_URL=http://localhost:3000/manifests/
+IIIF_MANIFEST_URL=http://localhost:3001/manifests/

--- a/app/controllers/manifests_controller.rb
+++ b/app/controllers/manifests_controller.rb
@@ -44,13 +44,13 @@ class ManifestsController < ApplicationController
     def item
       return @item if @item
 
-      prefix, path = params[:id].split(':', 2)
-      raise BadRequestError, 'Manifest ID must be in the form prefix:local' unless prefix && path
+      prefix, local_id = params[:id].split(':', 2)
+      raise BadRequestError, 'Manifest ID must be in the form prefix:local' unless prefix && local_id
 
       begin
         require "iiif/#{prefix}"
         classname = "IIIF::#{prefix.capitalize}::Item".constantize
-        @item = classname.new(path, params[:q])
+        @item = classname.new(local_id, params[:q])
       rescue LoadError
         raise NotFoundError, "Unrecognized prefix '#{prefix}'"
       end

--- a/config/iiif.yml
+++ b/config/iiif.yml
@@ -3,7 +3,7 @@
 default: &default
     fcrepo:
         fcrepo_url: <%= ENV['FCREPO_URL'] %>
-        solr_url: <%= ENV['SOLR_URL'] %>
+        solr_url: <%= ENV['FCREPO_SOLR_URL'] %>
         image_url: <%= ENV['IIIF_IMAGE_URL'] %>
         manifest_url: <%= ENV['IIIF_MANIFEST_URL'] %>
     fedora2:

--- a/lib/iiif/fcrepo.rb
+++ b/lib/iiif/fcrepo.rb
@@ -129,11 +129,11 @@ module IIIF
           q: "id:#{@uri.gsub(':', '\:')}",
           wt: 'json',
           fl: 'id,rdf_type,component,containing_issue,display_title,date,issue_edition,issue_volume,issue_issue,' \
-            'rights,pages:[subquery],citation,display_date,image_height,image_width,mime_type',
+            'rights,pcdm_members,pages:[subquery],citation,display_date,image_height,image_width,mime_type',
           rows: 1,
           'pages.q': '{!terms f=id v=$row.pcdm_members}',
           'pages.fq': 'component:Page',
-          'pages.fl': 'id,display_title,page_number,images:[subquery]',
+          'pages.fl': 'id,display_title,page_number,pcdm_files,images:[subquery]',
           'pages.sort': 'page_number asc',
           'pages.rows': '1000',
           'pages.images.q': '{!terms f=id v=$row.pcdm_files}',
@@ -168,7 +168,7 @@ module IIIF
           page.uri = page_doc[:id]
           page.id = Path.from_uri(page.uri).to_prefixed
           page.label = "Page #{page_doc[:page_number]}"
-          page.image = get_image(page_doc[:images])
+          page.image = get_image(page_doc[:images][:docs])
         end
       end
 


### PR DESCRIPTION
Updated URLs for modified IIIF stack:

* use localhost:8182 for Cantaloupe
* use localhost:3001 for pcdm-manifests (reserves port 3000 for Archelon)
* include context path for fcrepo
* removed the redundant SOLR_URL environment variable

Other general fixes and improvements:
* Standardized the terminology around fcrepo location strings.
  * uri: the fully qualified URI to the resource
  * path: the full path to the resource inside the repo, without the leading slash
  * prefixed: slashes in the full path replaced with colons, and "fcrepo:" prepended
  * abbreviated: prefixed form, but with any pairtree sequences replaced with a "::"
* De-duplicated the constants in IIIF::Fcrepo and IIIF::Fcrepo::Item.
* Create a get_subquery_docs() helper method. Encapsulates the difference between how Solr 6 and Solr 7+ return subquery results.

https://issues.umd.edu/browse/LIBIIIF-140