### PR TITLE
LIBIIIF-179. Updated Solr fields in fcrepo handler to use new Solr index structures.

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -2,7 +2,7 @@
 FCREPO_URL=http://fcrepo-local:8080/fcrepo/rest/
 
 # URL of the fcrepo solr core
-FCREPO_SOLR_URL=http://localhost:8983/solr/fedora4/
+FCREPO_SOLR_URL=http://localhost:8985/solr/fcrepo/
 
 # URL of the Fedora 2 server
 FEDORA2_URL=https://fedoradev.lib.umd.edu/

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ config/pcdm2manifest.yml
 
 # Ignore environment variables
 /.env
+
+/vendor/bundle

--- a/lib/iiif/fcrepo.rb
+++ b/lib/iiif/fcrepo.rb
@@ -112,7 +112,7 @@ module IIIF
 
       def base_uri
         # base URI of the manifest resources
-        "#{CONFIG[:manifest_url]}#{@path.to_prefixed}/"
+        "#{CONFIG[:manifest_url]}#{@path.to_prefixed(abbreviate: false)}/"
       end
 
       attr_reader :query
@@ -141,9 +141,9 @@ module IIIF
 
       def manifest_id
         if canvas_level?
-          Path.from_uri(doc[:page__member_of__uri]).to_prefixed
+          Path.from_uri(doc[:page__member_of__uri]).to_prefixed(abbreviate: false)
         else
-          Path.from_uri(@uri).to_prefixed
+          Path.from_uri(@uri).to_prefixed(abbreviate: false)
         end
       end
 
@@ -158,7 +158,7 @@ module IIIF
       def get_page(_doc, page_doc)
         IIIF::Page.new.tap do |page|
           page.uri = page_doc[:id]
-          page.id = Path.from_uri(page.uri).to_abbreviated
+          page.id = Path.from_uri(page.uri).to_prefixed(abbreviate: false)
           page.label = page_doc[:page__title__txt]
           page.image = get_image(page_doc[:page__has_file])
         end

--- a/lib/iiif_base.rb
+++ b/lib/iiif_base.rb
@@ -125,7 +125,7 @@ module IIIF
       end
     end
 
-    def manifest # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
+    def manifest # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
       {
         '@context' => 'http://iiif.io/api/presentation/2/context.json',
         '@id' => manifest_uri,
@@ -173,12 +173,8 @@ module IIIF
       width = 80
       height = 100
       {
-        '@id' => image_uri(image.id, size: "#{width},#{height}"),
-        'service' => {
-          '@context' => 'http://iiif.io/api/image/2/context.json',
-          '@id' => image_uri(image.id),
-          'profile' => 'http://iiif.io/api/image/2/level1.json'
-        },
+        '@id' => image_uri(image.id, size: "#{width},"),
+        'service' => image_service(image_uri(image.id)),
         'format' => 'image/jpeg',
         'width' => width,
         'height' => height

--- a/lib/iiif_base.rb
+++ b/lib/iiif_base.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'http_utils'
 require 'erb'
 
 module IIIF
@@ -72,40 +73,73 @@ module IIIF
       }
     end
 
-    def canvases # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
-      pages.map do |page| # rubocop:disable Metrics/BlockLength
-        image = page.image
-        {
-          '@id' => canvas_uri(page.id),
-          '@type' => 'sc:Canvas',
-          'label' => page.label,
-          'height' => image.height || DEFAULT_CANVAS_HEIGHT,
-          'width' => image.width || DEFAULT_CANVAS_WIDTH,
+    def canvas(page) # rubocop:disable Metrics/MethodLength
+      annotation = image_annotation(page)
+      {
+        '@id' => canvas_uri(page.id),
+        '@type' => 'sc:Canvas',
+        'label' => page.label,
+        'height' => annotation.dig('resource', 'height') || DEFAULT_CANVAS_HEIGHT,
+        'width' => annotation.dig('resource', 'width') || DEFAULT_CANVAS_WIDTH,
+        'images' => annotation ? [annotation] : [],
+        'thumbnail' => thumbnail(page.image),
+        'otherContent' => other_content(page)
+      }
+    end
 
-          'images' => [
-            {
-              '@id' => annotation_uri(image.id),
-              '@type' => 'oa:Annotation',
-              'motivation' => 'sc:painting',
-              'resource' => {
-                '@id' => image_uri(image.id),
-                '@type' => 'dctypes:Image',
-                'format' => 'image/jpeg',
-                'service' => {
-                  '@context' => 'http://iiif.io/api/image/2/context.json',
-                  '@id' => image_uri(image.id),
-                  'profile' => 'http://iiif.io/api/image/2/profiles/level2.json'
-                },
-                'height' => image.height || DEFAULT_CANVAS_HEIGHT,
-                'width' => image.width || DEFAULT_CANVAS_WIDTH
-              },
-              'on' => canvas_uri(page.id)
-            }
-          ],
-          'thumbnail' => thumbnail(image),
-          'otherContent' => other_content(page)
-        }
+    def canvases
+      pages.map { |page| canvas(page) }
+    end
+
+    def image_dimensions(image)
+      # use the dimensions found in the index, if present
+      return { w: image.width, h: image.height } if image.height && image.width
+
+      # otherwise, attempt retrieve from the image server
+      # only fall back to the defaults if we cannot contact the image server
+      begin
+        response = HttpUtils::HTTP_CONN.get "#{image_uri(image.id)}/info.json"
+        return { w: DEFAULT_CANVAS_WIDTH, h: DEFAULT_CANVAS_HEIGHT } unless response.success?
+
+        info = response.body
+        { w: info['width'], h: info['height'] }
+      rescue Faraday::ConnectionFailed
+        { w: DEFAULT_CANVAS_WIDTH, h: DEFAULT_CANVAS_HEIGHT }
       end
+    end
+
+    def image_service(iiif_image_uri, iiif_version = 2, level = 2)
+      {
+        '@context' => "http://iiif.io/api/image/#{iiif_version}/context.json",
+        '@id' => iiif_image_uri,
+        'profile' => "http://iiif.io/api/image/#{iiif_version}/profiles/level#{level}.json"
+      }
+    end
+
+    def image_annotation(page)
+      return unless page.image
+
+      image = page.image
+      {
+        '@id' => annotation_uri(image.id),
+        '@type' => 'oa:Annotation',
+        'motivation' => 'sc:painting',
+        'resource' => image_resource(page.image),
+        'on' => canvas_uri(page.id)
+      }
+    end
+
+    def image_resource(image)
+      iiif_image_uri = image_uri(image.id)
+      image_size = image_dimensions(image)
+      {
+        '@id' => iiif_image_uri,
+        '@type' => 'dctypes:Image',
+        'format' => 'image/jpeg',
+        'service' => image_service(iiif_image_uri),
+        'height' => image_size[:h],
+        'width' => image_size[:w]
+      }
     end
 
     def other_content(page) # rubocop:disable Metrics/MethodLength
@@ -134,15 +168,14 @@ module IIIF
         'metadata' => metadata,
         'sequences' => sequences(pages),
         'thumbnail' => thumbnail(pages&.first&.image),
-        'logo' => logo
-      }.tap do |manifest|
-        manifest['navDate'] = nav_date if nav_date
-        manifest['license'] = license if license
-        manifest['attribution'] = attribution if attribution
-        manifest['description'] = description if description
-        manifest['viewing_direction'] = viewing_direction if viewing_direction
-        manifest['viewing_hint'] = viewing_hint if viewing_hint
-      end
+        'logo' => logo,
+        'navDate' => nav_date,
+        'license' => license,
+        'attribution' => attribution,
+        'description' => description,
+        'viewing_direction' => viewing_direction,
+        'viewing_hint' => viewing_hint
+      }.filter { |_k, v| v }
     end
 
     def logo
@@ -167,17 +200,14 @@ module IIIF
       }
     end
 
-    def thumbnail(image) # rubocop:disable Metrics/MethodLength
+    def thumbnail(image, width = 100)
       return {} if image.nil?
 
-      width = 80
-      height = 100
       {
         '@id' => image_uri(image.id, size: "#{width},"),
         'service' => image_service(image_uri(image.id)),
         'format' => 'image/jpeg',
-        'width' => width,
-        'height' => height
+        'width' => width
       }
     end
 


### PR DESCRIPTION
* Updated Solr fields in fcrepo handler to use new Solr index structures.
  - updated Solr endpoint in the development .env file
* Ignore "/vendor/bundle".
* Get the image dimensions from the IIIF Image server if they are not in the index.
  - respect the aspect ratio of thumbnails
  - further subdivided the IIIF base methods into smaller self-contained chunks
* Don't abbreviate the IIIF IDs.
  - Use the full version of the IIIF ID (without abbreviating the pairtree) so that lookups via the Solr `iiif_manifest__*` fields are easier.

https://umd-dit.atlassian.net/browse/LIBIIIF-179