### PR TITLE
LIBIIIF-181. Full text search with solrizer-creatred index.

### DIFF
--- a/lib/iiif/fcrepo.rb
+++ b/lib/iiif/fcrepo.rb
@@ -248,6 +248,8 @@ module IIIF
 
         docs = results['response']['docs']
         body = docs.select { |doc| doc['id'] == @uri }.first
+        raise Errors::NotFoundError if body.nil?
+
         page_sequence = body['page_uri__sequence']
         annotations = get_ocr_annotations(
           page_uri: page_uri,

--- a/lib/iiif/fcrepo.rb
+++ b/lib/iiif/fcrepo.rb
@@ -320,8 +320,8 @@ module IIIF
                     # NOTE: need the [0] subscript since `scan()` with capture groups returns an iterator of arrays
                     # rather than single string values
                     # ALSO NOTE: if there are multiword matches, each word gets highlighted individually; if we wanted
-                    # to change this, we would need to collapse the values and coordinates in the scan for `COORD_PATTERN`
-                    # into a single annotation for each hit
+                    # to change this, we would need to collapse the values and coordinates in the scan for the
+                    # `COORD_PATTERN` into a single annotation for each hit
                     hit[0].scan COORD_PATTERN do |value, tag_string|
                       tags = Rack::Utils.parse_nested_query(tag_string)
                       if tags['n'].to_i == page_index

--- a/lib/iiif_base.rb
+++ b/lib/iiif_base.rb
@@ -142,14 +142,15 @@ module IIIF
       }
     end
 
-    def other_content(page) # rubocop:disable Metrics/MethodLength
+    def other_content(page)
       [].tap do |other|
-        if methods.include?(:textblock_list)
-          other.push(
-            '@id' => list_uri(page.id),
-            '@type' => 'sc:AnnotationList'
-          )
-        end
+        # XXX: temporarily disabled
+        # if methods.include?(:textblock_list)
+        #   other.push(
+        #     '@id' => list_uri(page.id),
+        #     '@type' => 'sc:AnnotationList'
+        #   )
+        # end
         if query && methods.include?(:search_hit_list)
           other.push(
             '@id' => "#{list_uri(page.id)}?q=#{encode(query)}",


### PR DESCRIPTION
- updated the query to match the new Solr fields
- made the list of OCR fields a module level variable
- refactored the search_hit_list into smaller component methods
- temporarily disabled the textblock list

https://umd-dit.atlassian.net/browse/LIBIIIF-181